### PR TITLE
Use new repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Asupkay/GenerativeArtwork.git"
+    "url": "git+https://github.com/Asupkay/Artblocks-Starter-Template.git"
   },
   "author": "Alex Supkay, Stephen McArdle",
   "license": "MIT",


### PR DESCRIPTION
I noticed the `package.json` still references the old repository URL. I think GitHub just redirects it, so it's not a huge problem. But probably better to fix it anyway.