### PR TITLE
Make compatible with Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node app.js

--- a/app.js
+++ b/app.js
@@ -4,7 +4,7 @@ const utils = require('./utils');
 const md = require('markdown-it')();
 
 const app = express();
-const port = 3000;
+const port = process.env.PORT || 3000;
 
 app.set('view engine', 'hbs');
 app.engine(
@@ -40,5 +40,5 @@ app.get('*', (req, res) => {
 });
 
 app.listen(port, () => {
-  console.log('Server running on port 3000');
+  console.log(`Server running on port ${port}`);
 });


### PR DESCRIPTION
This PR adds two changes that make it compatible with Heroku and presumably other web servers.

It makes the port configurable (but still falls back to `3000`). And it adds a Procfile which PaaS services like Heroku require to start the server.

Both changes should be fully backwards compatible and make it easier to get the app up-and-running in various places.