### PR TITLE
Fix p5js library, so that it uses the same version ArtBlocks uses.

### DIFF
--- a/views/layouts/index.hbs
+++ b/views/layouts/index.hbs
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />  
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>Art Blocks Template</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <link href="https://fonts.googleapis.com/css2?family=Bungee+Shade&display=swap" rel="stylesheet">
@@ -11,7 +11,7 @@
     <script>
       // Generates a random hash and token id each time you reload, in the following format
       //let tokenData = {"hash":"0xd9134c11cd5ed9798ea0811364d63bd850c69c5d13383c9983ade39847e9ea86","tokenId":"99000000"};
-      
+
       function genTokenData(projectNum)
       {
           let data = {};
@@ -27,7 +27,7 @@
       let tokenData = genTokenData(99);
     </script>
     <script src="./js/three.min.js"></script>
-    <script src="./js/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.0.0/p5.min.js"></script>
   </head>
   <body>
     {{{body}}}


### PR DESCRIPTION
This library uses an incorrect p5js version, because, due to the mistake in p5, 1.0.0 p5js is different in different distributions.
(See https://github.com/processing/p5.js/issues/5728 issue for more).

I fixed it so that this library takes p5js from the same place as AB does.